### PR TITLE
Add About page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -112,9 +112,13 @@ hr {
     transition: all 1s ease;
 }
 
-a { 
+nav > a { 
 	color: white;
 	text-decoration: none;
+}
+a {
+	color: black;
+	text-decoration: underline;
 }
 
 .list-item {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -112,7 +112,7 @@ hr {
     transition: all 1s ease;
 }
 
-nav > a { 
+nav a { 
 	color: white;
 	text-decoration: none;
 }

--- a/views/about.html
+++ b/views/about.html
@@ -22,5 +22,12 @@
       <a href="about">About</a>
     </div>
   </nav>
+  <main>
+    <h1>About</h1>
+    <p>In 2017, <a href="https://scratch.mit.edu/" title="Scratch's homepage">Scratch</a>, a project by MIT, <a href="https://scratch.mit.edu/discuss/topic/284272/" title="Forum thread">banned</a> referencing user generated extensions publically on the site; for the protection of the users. This was quite a controversial decision, some people likinging it; and others hating it.</p>
+    <p>Since extensions cannot be advertised, we've decided to create a central resource for them, here. All extensions are reviewed by our team to ensure that they won't take over your account. We will also start to add labels explaining what data is collected.</p>
+    <p>Additionally, all extensions will be reviewed by the stores that host them.</p>
+    <p>If you've made an extension, please provide us with clear code that has not been minified. We encourage you to use a free (as in speech) licence for your software.</p>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
This pull request fixes #6.

Changes

+ Adds content to about page (in the form of text).
+ Changes style for `a` to style for `nav a` to ensure that links in the aforementioned content are readable.